### PR TITLE
Add AUD before every nal unit

### DIFF
--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/TSMuxer.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/muxers/ts/TSMuxer.kt
@@ -31,6 +31,7 @@ import io.github.thibaultbee.streampack.internal.muxers.ts.packets.Sdt
 import io.github.thibaultbee.streampack.internal.muxers.ts.utils.MuxerConst
 import io.github.thibaultbee.streampack.internal.muxers.ts.utils.TSConst
 import io.github.thibaultbee.streampack.internal.utils.av.audio.aac.ADTS
+import io.github.thibaultbee.streampack.internal.utils.isVideo
 import java.nio.ByteBuffer
 import java.util.*
 import kotlin.random.Random
@@ -86,6 +87,14 @@ class TSMuxer(
         val pes = getPes(streamPid.toShort())
         when (frame.mimeType) {
             MediaFormat.MIMETYPE_VIDEO_AVC -> {
+                frame.buffer = ByteBuffer.allocate(6 + frame.buffer.limit()).apply {
+                    putInt(0x00000001)
+                    put(0x09.toByte())
+                    put(0xf0.toByte())
+                    put(frame.buffer)
+                    flip()
+                }
+
                 // Copy sps & pps before buffer
                 if (frame.isKeyFrame) {
                     if (frame.extra == null) {


### PR DESCRIPTION
This change is to improve compatibility with the MPEGTS spec, that says:
> 2.14.1 "Each AVC access unit shall contain an access unit delimiter NAL Unit"

From what I tested, this change does not appear to fix anything, but I only checked it with ffmpeg and OBS.
There might be other software, that take those AUDs into consideration.
For example, AUDs can be used to count frames in TS: https://www.ramugedia.com/how-count-avc-h-264-video-frames-in-transport-stream-file-