### PR TITLE
Fix PIP mode orientation

### DIFF
--- a/core/src/main/java/io/github/thibaultbee/streampack/internal/utils/extensions/ContextExtensions.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/internal/utils/extensions/ContextExtensions.kt
@@ -16,11 +16,12 @@
 package io.github.thibaultbee.streampack.internal.utils.extensions
 
 import android.content.Context
-import android.content.res.Configuration.ORIENTATION_LANDSCAPE
-import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.hardware.display.DisplayManager
+import android.util.Size
 import android.view.Display
 import android.view.Surface
+import androidx.core.content.ContextCompat
+import androidx.core.view.DisplayCompat
 import io.github.thibaultbee.streampack.R
 import io.github.thibaultbee.streampack.internal.muxers.ts.data.TsServiceInfo
 import io.github.thibaultbee.streampack.utils.OrientationUtils
@@ -53,7 +54,19 @@ val Context.deviceOrientation: Int
  * @return true if the device is in portrait, otherwise false
  */
 val Context.isDevicePortrait: Boolean
-    get() = resources.configuration.orientation == ORIENTATION_PORTRAIT
+    get() {
+        val display = ContextCompat.getDisplayOrDefault(this)
+        val mode = DisplayCompat.getMode(this, display)
+        val naturalResolution = Size(mode.physicalWidth, mode.physicalHeight)
+        val naturalIsPortrait = naturalResolution.isPortrait
+        return when (display.rotation) {
+            Surface.ROTATION_0   -> naturalIsPortrait
+            Surface.ROTATION_90  -> !naturalIsPortrait
+            Surface.ROTATION_180 -> naturalIsPortrait
+            Surface.ROTATION_270 -> !naturalIsPortrait
+            else                 -> naturalIsPortrait
+        }
+    }
 
 
 /**
@@ -62,7 +75,7 @@ val Context.isDevicePortrait: Boolean
  * @return true if the device is in landscape, otherwise false
  */
 val Context.isDeviceLandscape: Boolean
-    get() = resources.configuration.orientation == ORIENTATION_LANDSCAPE
+    get() = !isDevicePortrait
 
 val Context.defaultTsServiceInfo
     get() = TsServiceInfo(

--- a/core/src/main/java/io/github/thibaultbee/streampack/views/PreviewView.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/views/PreviewView.kt
@@ -93,9 +93,7 @@ class PreviewView @JvmOverloads constructor(
         set(value) {
             stopPreviewInternal()
             value?.let {
-                lifecycleScope?.launch {
-                    startPreviewInternal(it, it.camera, size)
-                }
+                startPreviewIfReady(it, size, true)
             }
             field = value
         }
@@ -269,7 +267,7 @@ class PreviewView @JvmOverloads constructor(
 
             lifecycleScope?.launch {
                 startPreviewInternal(streamer, streamer.camera, targetViewSize)
-            } ?: throw IllegalStateException("LifecycleScope is not available")
+            } ?: Logger.w(TAG, "Trying to start preview but lifecycle scope is not available")
         } catch (e: Exception) {
             if (shouldFailSilently) {
                 Logger.w(TAG, e.toString(), e)

--- a/demos/camera/build.gradle
+++ b/demos/camera/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation project(':extension-rtmp')
     implementation project(':extension-srt')
 
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.core:core-ktx:${androidxCoreVersion}"
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/demos/camera/build.gradle
+++ b/demos/camera/build.gradle
@@ -66,5 +66,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/demos/screenrecorder/build.gradle
+++ b/demos/screenrecorder/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation project(':extension-srt')
 
     implementation "androidx.core:core-ktx:${androidxCoreVersion}"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.7.7'

--- a/demos/screenrecorder/build.gradle
+++ b/demos/screenrecorder/build.gradle
@@ -62,5 +62,5 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }


### PR DESCRIPTION
When app is in PIP mode, it is possible that the device is in different orientation than the app. In this case the stream is of wrong aspect ratio and rotation. I fixed this problem in my app by changing the Context.isDevicePortrait to actually give device orientation instead of application orientation (since orientation provider otherwise uses the device orientation).

On the implementation:
Display.getRotation() gives the rotation from the "natural" orientation of the device so my code tries to figure out the natural orientation of the device from its physical size. I don't have a device with natural orientation of landscape so I can't be sure it works on those devices.