### PR TITLE
feat(ui): render preview of correct size in landscape orientation for non-camera sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# StreamPack: RTMP and [SRT](https://github.com/Haivision/srt) live streaming SDK for Android
+# StreamPack: RTMP and SRT live streaming SDK for Android
 
 StreamPack is a flexible live streaming library for Android made for both demanding video
 broadcasters and new video enthusiasts.
 
-It is designed to be used in live streaming and gaming apps.
+## Hop On Board! 🚀
+
+⭐ If you like this project, don’t forget to star it!
+💖 Want to support its development? Consider becoming a sponsor.
+🛠️ Contributions are welcome—feel free to open issues or submit pull requests!
 
 ## Setup
 

--- a/ui/src/main/java/io/github/thibaultbee/streampack/ui/views/PreviewView.kt
+++ b/ui/src/main/java/io/github/thibaultbee/streampack/ui/views/PreviewView.kt
@@ -431,7 +431,10 @@ class PreviewView @JvmOverloads constructor(
                 context.getCameraCharacteristics(videoSource.cameraId)
             builder.populateFromCharacteristics(cameraCharacteristics).build()
         } else {
-            builder.build()
+            val rotationDegrees = OrientationUtils.getSurfaceRotationDegrees(display.rotation)
+            builder
+                .setSourceOrientation(rotationDegrees)
+                .build()
         }.also { request ->
             val surface = withContext(coroutineContext + supervisorJob) {
                 viewfinder.requestSurface(request)


### PR DESCRIPTION
Makes preview aware of display orientation allowing it to correctly display bitmap and other non-camera previewable sources.

Implements Git Issue https://github.com/ThibaultBee/StreamPack/issues/238.

## In camera demo `PreviewView` is in "fill" mode by default

### "Fill" Before

Portrait is fine.

<img height="540" alt="before-port-fill" src="https://github.com/user-attachments/assets/da61c10c-6a66-40f8-9d2f-5640aa2b4b36" />

In landscape bitmap is wrong size, stretched vertically.

<img width="1200" height="540" alt="before-land-fill" src="https://github.com/user-attachments/assets/b0238051-2724-4016-8c3e-cf104428bfd0" />

### "Fill" After

In portrait nothing changed. Correct.

<img height="540" alt="after-port-fill" src="https://github.com/user-attachments/assets/075878d9-4c86-4c36-ab13-b7d3f0c0252c" />

Landscape shows correct bitmap proportions.

<img width="1200" height="540" alt="after-land-fill" src="https://github.com/user-attachments/assets/4a8a30e3-e98f-407d-8a94-282e14da325d" />

## It's more evident in "fit" mode of `PreviewView`

Portrait is fine.

<img height="540" alt="before-port-fit" src="https://github.com/user-attachments/assets/9faa798f-0638-4ba5-8065-7034a63d74fb" />

In landscape bitmap is wrong size, stretched vertically.

<img width="1200" height="540" alt="before-landscape-fit" src="https://github.com/user-attachments/assets/ceb67c77-26a2-4bbd-b0b6-1b37356b6066" />

### "Fit" After

In portrait nothing changed. Correct.

<img height="540" alt="after-port-fit" src="https://github.com/user-attachments/assets/90d095c4-54f2-40ad-99c0-5261a7365184" />

Landscape now shows correct bitmap proportions.

<img width="1200" height="540" alt="after-land-fit" src="https://github.com/user-attachments/assets/cb2ee61d-5199-4160-9760-9a5cd6f396bc" />
