### PR TITLE
fix(ts): avoid Long overflow in PCR computation after long uptime

### DIFF
--- a/core/src/main/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationField.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationField.kt
@@ -86,23 +86,14 @@ class AdaptationField(
         return buffer
     }
 
-    private fun addClockReference(buffer: ByteBuffer, timestamp: Long) {
-        // PATCH LOCALE (regia-rtmp, 9/8): la formula originale calcola
-        // SYSTEM_CLOCK_FREQ(27_000_000) * timestamp PRIMA di dividere — con
-        // timestamp in microsecondi di uptime del device (TimeUtils.currentTime()
-        // usa SystemClock.uptimeMillis()-equivalente), questo prodotto sfora un
-        // Long a 64 bit (overflow silenzioso in Kotlin/JVM) non appena l'uptime
-        // supera ~95 ore (~3.95 giorni): 27_000_000 * timestamp > Long.MAX_VALUE
-        // quando timestamp > ~3.416e11 µs. Il valore avvolto (wrapped) produce
-        // un PCR sostanzialmente casuale ad ogni frame — root cause isolata sul
-        // campo di un blocco totale/intermittente della ridistribuzione RTSP/
-        // SRT-pull/HLS su mediamtx per stream pubblicati da device con uptime
-        // lungo (7 giorni nel caso diagnosticato). Riscritto nello stesso ordine
-        // di operazioni già usato da RootEncoder (pedroSG94/RootEncoder,
-        // srt/.../AdaptationField.kt: "timestamp * 9 / 100"), che moltiplica per
-        // un fattore piccolo prima di dividere — matematicamente equivalente
-        // (27_000_000/1_000_000/300 = 9/100) ma sicuro fino a timestamp
-        // dell'ordine di 10^17 µs (~milioni di anni di uptime).
+    internal fun addClockReference(buffer: ByteBuffer, timestamp: Long) {
+        // SYSTEM_CLOCK_FREQ * timestamp is evaluated before any division: with
+        // timestamp in microseconds (device uptime based), the product overflows
+        // Long after ~95h of uptime (~3.4e11 µs) and silently wraps in Kotlin/
+        // JVM, producing a garbage PCR on every subsequent frame. Rewritten in
+        // the same order as RootEncoder's AdaptationField (timestamp * 9 / 100):
+        // mathematically equivalent (27_000_000 / 1_000_000 / 300 = 9/100) but
+        // safe for timestamps up to ~10^17 µs.
         val pcrBase = (timestamp * 9 / 100) % (1L shl 33)
         val pcrExt = (timestamp * 27) % 300
 

--- a/core/src/main/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationField.kt
+++ b/core/src/main/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationField.kt
@@ -87,11 +87,24 @@ class AdaptationField(
     }
 
     private fun addClockReference(buffer: ByteBuffer, timestamp: Long) {
-        val pcrBase =
-            (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */ / 300) % 2.toDouble()
-                .pow(33)
-                .toLong()
-        val pcrExt = (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */) % 300
+        // PATCH LOCALE (regia-rtmp, 9/8): la formula originale calcola
+        // SYSTEM_CLOCK_FREQ(27_000_000) * timestamp PRIMA di dividere — con
+        // timestamp in microsecondi di uptime del device (TimeUtils.currentTime()
+        // usa SystemClock.uptimeMillis()-equivalente), questo prodotto sfora un
+        // Long a 64 bit (overflow silenzioso in Kotlin/JVM) non appena l'uptime
+        // supera ~95 ore (~3.95 giorni): 27_000_000 * timestamp > Long.MAX_VALUE
+        // quando timestamp > ~3.416e11 µs. Il valore avvolto (wrapped) produce
+        // un PCR sostanzialmente casuale ad ogni frame — root cause isolata sul
+        // campo di un blocco totale/intermittente della ridistribuzione RTSP/
+        // SRT-pull/HLS su mediamtx per stream pubblicati da device con uptime
+        // lungo (7 giorni nel caso diagnosticato). Riscritto nello stesso ordine
+        // di operazioni già usato da RootEncoder (pedroSG94/RootEncoder,
+        // srt/.../AdaptationField.kt: "timestamp * 9 / 100"), che moltiplica per
+        // un fattore piccolo prima di dividere — matematicamente equivalente
+        // (27_000_000/1_000_000/300 = 9/100) ma sicuro fino a timestamp
+        // dell'ordine di 10^17 µs (~milioni di anni di uptime).
+        val pcrBase = (timestamp * 9 / 100) % (1L shl 33)
+        val pcrExt = (timestamp * 27) % 300
 
         /**
          * PCR Base -> 33 bits

--- a/core/src/test/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationFieldTest.kt
+++ b/core/src/test/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationFieldTest.kt
@@ -22,6 +22,7 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.math.BigInteger
+import java.nio.ByteBuffer
 
 class AdaptationFieldTest {
 
@@ -53,10 +54,9 @@ class AdaptationFieldTest {
         // (SYSTEM_CLOCK_FREQ * timestamp evaluated before any division),
         // 27_000_000 * 400_000_000_000 = 1.08e19 overflows Long.MAX_VALUE
         // (~9.223e18) and silently wraps in Kotlin/JVM, corrupting the PCR of
-        // every frame past ~95h of uptime (~3.4e11 us). This reproduces that
-        // magnitude and checks the encoded PCR against a ground truth computed
-        // with BigInteger (same original semantics, immune to Long overflow at
-        // this size) instead of against the patched formula itself.
+        // every frame past ~95h of uptime (~3.4e11 us). The expected PCR is
+        // computed with BigInteger (same original semantics, immune to Long
+        // overflow at this size) instead of with the patched formula itself.
         val timestamp = 400_000_000_000L
 
         val adaptationField = AdaptationField(
@@ -70,10 +70,13 @@ class AdaptationFieldTest {
             adaptationFieldExtension = null
         )
 
-        val bytes = adaptationField.toByteBuffer()
-        bytes.position(2) // skip adaptation_field_length + flags byte
-        val pcrBaseHigh32 = bytes.int.toLong() and 0xFFFFFFFFL
-        val tail = bytes.short.toInt() and 0xFFFF
+        // addClockReference writes pcrBase (4 bytes, 33 bits shifted left by
+        // one) then pcrExt + reserved (2 bytes).
+        val buffer = ByteBuffer.allocate(6)
+        adaptationField.addClockReference(buffer, timestamp)
+        buffer.rewind()
+        val pcrBaseHigh32 = buffer.int.toLong() and 0xFFFFFFFFL
+        val tail = buffer.short.toInt() and 0xFFFF
         val actualPcrBase = (pcrBaseHigh32 shl 1) or ((tail.toLong() shr 15) and 0x1L)
         val actualPcrExt = tail and 0x1FF
 

--- a/core/src/test/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationFieldTest.kt
+++ b/core/src/test/java/io/github/thibaultbee/streampack/core/elements/endpoints/composites/muxers/ts/descriptors/AdaptationFieldTest.kt
@@ -16,9 +16,12 @@
 package io.github.thibaultbee.streampack.core.elements.endpoints.composites.muxers.ts.descriptors
 
 import io.github.thibaultbee.streampack.core.elements.endpoints.composites.muxers.ts.TSResourcesUtils
+import io.github.thibaultbee.streampack.core.elements.endpoints.composites.muxers.ts.utils.TSConst
 import io.github.thibaultbee.streampack.core.elements.utils.extensions.toByteArray
 import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.math.BigInteger
 
 class AdaptationFieldTest {
 
@@ -42,5 +45,48 @@ class AdaptationFieldTest {
             expectedAdaptationField.array(),
             adaptationField.toByteBuffer().toByteArray()
         )
+    }
+
+    @Test
+    fun `pcr does not overflow after long device uptime`() {
+        // 400_000_000_000 microseconds ~= 4.63 days. With the pre-fix formula
+        // (SYSTEM_CLOCK_FREQ * timestamp evaluated before any division),
+        // 27_000_000 * 400_000_000_000 = 1.08e19 overflows Long.MAX_VALUE
+        // (~9.223e18) and silently wraps in Kotlin/JVM, corrupting the PCR of
+        // every frame past ~95h of uptime (~3.4e11 us). This reproduces that
+        // magnitude and checks the encoded PCR against a ground truth computed
+        // with BigInteger (same original semantics, immune to Long overflow at
+        // this size) instead of against the patched formula itself.
+        val timestamp = 400_000_000_000L
+
+        val adaptationField = AdaptationField(
+            discontinuityIndicator = false,
+            randomAccessIndicator = true,
+            elementaryStreamPriorityIndicator = false,
+            programClockReference = timestamp,
+            originalProgramClockReference = null,
+            spliceCountdown = null,
+            transportPrivateData = null,
+            adaptationFieldExtension = null
+        )
+
+        val bytes = adaptationField.toByteBuffer()
+        bytes.position(2) // skip adaptation_field_length + flags byte
+        val pcrBaseHigh32 = bytes.int.toLong() and 0xFFFFFFFFL
+        val tail = bytes.short.toInt() and 0xFFFF
+        val actualPcrBase = (pcrBaseHigh32 shl 1) or ((tail.toLong() shr 15) and 0x1L)
+        val actualPcrExt = tail and 0x1FF
+
+        val freq = BigInteger.valueOf(TSConst.SYSTEM_CLOCK_FREQ.toLong())
+        val ts = BigInteger.valueOf(timestamp)
+        val twoPow33 = BigInteger.ONE.shiftLeft(33)
+        val expectedPcrBase =
+            freq.multiply(ts).divide(BigInteger.valueOf(1_000_000)).divide(BigInteger.valueOf(300))
+                .mod(twoPow33).toLong()
+        val expectedPcrExt =
+            freq.multiply(ts).divide(BigInteger.valueOf(1_000_000)).mod(BigInteger.valueOf(300)).toInt()
+
+        assertEquals(expectedPcrBase, actualPcrBase)
+        assertEquals(expectedPcrExt, actualPcrExt)
     }
 }


### PR DESCRIPTION
# Title: PCR computation overflows Long after ~95h of device uptime, corrupting the TS mux (silent, breaks RTSP/SRT-pull/HLS re-distribution)

## Environment

- StreamPack 3.2.0 (core + srt extension)
- Android device with long uptime (observed after ~7 days of uptime, but the
  threshold is deterministic and codec-independent, see below)
- MPEG-TS output (TS muxer, used by the SRT endpoint)
- Downstream: media server re-distributing the SRT-pushed TS (mediamtx, but
  this is a bug in the TS stream itself, not in the downstream server)

## Symptom

After the device has been running for a long time (multiple days), the
MPEG-TS stream pushed over SRT becomes corrupt in a way that a re-distributing
media server can no longer parse it: total or intermittent failure of
RTSP-pull / SRT-pull / HLS re-serving of the same stream from a server that
otherwise successfully receives and forwards it (confirmed the bytes were
arriving over the SRT socket — the corruption is in the PCR field itself, not
in transport). The device's own SRT push connection stays up throughout; only
downstream re-muxing/re-parsing breaks.

## Root cause

`AdaptationField.addClockReference()`:

```kotlin
private fun addClockReference(buffer: ByteBuffer, timestamp: Long) {
    val pcrBase =
        (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */ / 300) % 2.toDouble()
            .pow(33)
            .toLong()
    val pcrExt = (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */) % 300
    ...
}
```

`timestamp` is a frame PTS in **microseconds**, typically derived from device
uptime (`SystemClock`-based clocks), so it grows unbounded across a long-lived
session. `TSConst.SYSTEM_CLOCK_FREQ` is `27_000_000`.

The multiplication `SYSTEM_CLOCK_FREQ * timestamp` is done **before** any
division. On the JVM/Kotlin, `Long * Long` silently wraps on overflow (no
exception). This product overflows `Long.MAX_VALUE` (2^63-1) once
`timestamp > ~3.416 × 10^11 µs`, i.e. **~95 hours (~3.95 days) of uptime** —
independent of video codec, resolution, or bitrate; it only depends on how
long the encoder has been feeding PTS values that trace real elapsed time.

Once the product overflows, `pcrBase`/`pcrExt` become effectively random
per-frame values instead of a monotonically increasing clock reference. The
resulting PCR field in every adaptation field from that point on is garbage.
Most simple TS consumers (HLS segmenters, players that ignore PCR jitter
within tolerance) are lenient enough not to notice; standards-strict RTSP/SRT
re-muxers reject or desync on it, which is how this was found (works for
HLS on the same server/path, breaks for RTSP/SRT re-pull of the identical
input).

This is silent and cumulative: nothing throws, nothing logs, and the bug only
manifests after days of uptime, which makes it easy to miss in normal
development/testing cycles (restart the app => PTS/uptime resets => bug
disappears until the next multi-day session).

## Fix

Reorder the arithmetic to divide before multiplying, same approach already
used by RootEncoder (pedroSG94/RootEncoder,
`extensions/srt/.../descriptor/AdaptationField.kt`, `timestamp * 9 / 100`),
which is mathematically equivalent since `27_000_000 / 1_000_000 / 300 = 9/100`
and `27_000_000 / 1_000_000 = 27`, but safe up to `timestamp` on the order of
`10^17` µs (millions of years of uptime) instead of `~3.4 × 10^11` µs:

```diff
     private fun addClockReference(buffer: ByteBuffer, timestamp: Long) {
-        val pcrBase =
-            (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */ / 300) % 2.toDouble()
-                .pow(33)
-                .toLong()
-        val pcrExt = (TSConst.SYSTEM_CLOCK_FREQ * timestamp / 1000000 /* µs -> s */) % 300
+        val pcrBase = (timestamp * 9 / 100) % (1L shl 33)
+        val pcrExt = (timestamp * 27) % 300
```

(`1L shl 33` replaces `2.toDouble().pow(33).toLong()` — same value, avoids an
unnecessary double round-trip, but that part is cosmetic; the load-bearing
change is the multiply/divide order.)

Verified on-device: after this fix, an SRT push kept running well past the
previous corruption threshold re-distributes cleanly via RTSP-pull/SRT-pull on
mediamtx with no PCR-related desync.

I'm happy to open a PR with this change if useful.
